### PR TITLE
Allow using the library with guzzlehttp/guzzle v7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,19 +9,18 @@
         }
     ],
     "require": {
-        "guzzlehttp/guzzle": "^6.2.1",
+        "guzzlehttp/guzzle": "^6.2.1|^7.0",
         "ext-json": "*",
         "swaggest/json-schema": "^0.12"
     },
     "require-dev": {
-        "swaggest/json-cli": "^1.9",
         "php-mock/php-mock-phpunit": "^2.1"
     },
     "autoload": {
         "psr-4": {"ShipStream\\SpsCommerce\\": "src/"}
     },
     "autoload-dev": {
-        "psr-4": {"ShipStream\\SpsCommerce\\Tests": "test/"}
+        "psr-4": {"ShipStream\\SpsCommerce\\Tests\\": "test/"}
     },
     "scripts": {
         "test": "vendor/bin/phpunit"


### PR DESCRIPTION
`swaggest/json-cli` uses a dependency that doesn't support PHP 8 and it not needed since `generate.sh` uses the docker image.